### PR TITLE
Add magazine document protobuf spec

### DIFF
--- a/lib/data_classes/protobuf/magazines.proto
+++ b/lib/data_classes/protobuf/magazines.proto
@@ -2,11 +2,12 @@ syntax = "proto3";
 package mymgs;
 
 message Magazine {
+  // Util for handling mixed image/text types
   enum ElementType {
     Text = 0;
     Image = 1;
   }
-
+  // Util for relative vs absolute units
   message Unit {
     enum UnitType {
       Px = 0;
@@ -87,7 +88,7 @@ message Magazine {
 
 
   message TextFormattingData {
-    enum FormattingType {
+    enum TextFormattingType {
       ITALICS = 0;
       UNDERLINE = 1;
       BOLD = 2;
@@ -124,7 +125,7 @@ message Magazine {
       BottomRight = 8;
     }
 
-    repeated FormattingType formattingType = 1;
+    repeated TextFormattingType formattingType = 1;
     optional TitleSize titleSize = 2;
     optional string textColor = 3;
 
@@ -151,8 +152,9 @@ message Magazine {
     }
 
     string altText = 3;
-    optional BorderData border = 4;
-    optional GlobalConsumer usingGlobal = 5;
+    optional string description = 4;
+    optional BorderData border = 5;
+    optional GlobalConsumer usingGlobal = 6;
   }
 
 

--- a/lib/data_classes/protobuf/magazines.proto
+++ b/lib/data_classes/protobuf/magazines.proto
@@ -2,5 +2,284 @@ syntax = "proto3";
 package mymgs;
 
 message Magazine {
-  string title = 1;
+  enum ElementType {
+    Text = 0;
+    Image = 1;
+  }
+
+  message Unit {
+    enum UnitType {
+      Px = 0;
+      ViewportWidth = 1;
+      ViewportHeight = 2;
+    }
+
+    UnitType type = 1;
+    float value = 2;
+  }
+
+
+  message GlobalConsumer {
+    string global = 1;
+    ElementType callingAs = 2;
+    map<string, string> args = 3;
+  }
+
+  message Global {
+    message ValueAccess {
+      message ArgAccess {
+        enum AccessType {
+          Float = 0;
+          Enum = 1;
+          String = 2;
+        }
+
+        string name = 1;
+        AccessType as = 2;
+      }
+
+      oneof ValueType {
+        float float = 1;
+        int32 enum = 2;
+        string string = 3;
+
+        ArgAccess arg = 4;
+      }
+    }
+
+    message ReturnedTextData {
+      repeated ValueAccess formattingType = 1;
+      optional ValueAccess titleSize = 2;
+      optional ValueAccess textColor = 3;
+    }
+
+    message ReturnedImageData {
+      message ReferencedUnit {
+        ValueAccess type = 1;
+        ValueAccess value = 2;
+      }
+
+      message BorderData {
+        ValueAccess sides = 1;
+        ValueAccess color = 2;
+        ValueAccess width = 3;
+      }
+
+      oneof DimensionSpecification {
+        ReferencedUnit width = 1;
+        ReferencedUnit height = 2;
+      }
+
+      optional BorderData border = 4;
+      ReferencedUnit altText = 3;
+    }
+
+
+    string key = 1;
+    ElementType acceptedType = 2;
+    repeated string args = 3;
+
+    oneof ReturnedData {
+      ReturnedTextData returnsTextData = 4;
+      ReturnedImageData returnsImageData = 5;
+    }
+  }
+
+
+  message TextFormattingData {
+    enum FormattingType {
+      ITALICS = 0;
+      UNDERLINE = 1;
+      BOLD = 2;
+      STRIKETHROUGH = 3;
+      SUPERSCRIPT = 4;
+      SUBSCRIPT = 5;
+      CODE = 6;
+    }
+
+    enum TitleSize {
+      H1 = 0;
+      H2 = 1;
+      H3 = 2;
+      H4 = 3;
+      H5 = 4;
+      H6 = 5;
+    }
+
+    enum InlineAlignment {
+      Left = 0;
+      Center = 1;
+      Right = 2;
+    }
+
+    enum AbsoluteAlignment {
+      TopLeft = 0;
+      TopCenter = 1;
+      TopRight = 2;
+      MiddleLeft = 3;
+      MiddleCenter = 4;
+      MiddleRight = 5;
+      BottomLeft = 6;
+      BottomCenter = 7;
+      BottomRight = 8;
+    }
+
+    repeated FormattingType formattingType = 1;
+    optional TitleSize titleSize = 2;
+    optional string textColor = 3;
+
+    optional GlobalConsumer usingGlobal = 4;
+  }
+
+  message ImageFormattingData {
+    message BorderData {
+      enum Sides {
+        Top = 0;
+        Right = 1;
+        Bottom = 2;
+        Left = 3;
+      }
+
+      Sides sides = 1;
+      string color = 2;
+      float width = 3;
+    }
+
+    oneof DimensionSpecification {
+      Unit width = 1;
+      Unit height = 2;
+    }
+
+    string altText = 3;
+    optional BorderData border = 4;
+    optional GlobalConsumer usingGlobal = 5;
+  }
+
+
+  message ImageSpecifier {
+      string sourceUrl = 1;
+      ImageFormattingData formatting = 2;
+  }
+
+  message StructuredTextSpecifier {
+    message TextFormattingInterpolation {
+      repeated StructuredTextSpecifier text = 1;
+      TextFormattingData formatting = 2;
+    }
+
+    oneof TextValue {
+      string text = 1;
+      ImageSpecifier image = 2;
+      TextFormattingInterpolation children = 3;
+    }
+
+    int32 index = 4;
+  }
+
+
+  message Master {
+    message BakedAlignmentData {
+      oneof PlaceBakedStructure {
+        string placeAfter = 1;
+        string placeBefore = 2;
+      }
+    }
+
+    message InlineAlignmentData {
+      TextFormattingData.InlineAlignment alignment = 1;
+      bool breakLine = 2;
+    }
+
+    message Mapper {
+      string key = 1;
+      int32 index = 2;
+      ElementType type = 3;
+
+      oneof TypeSpecificSpec {
+        ImageFormattingData imageFormatting = 4;
+        TextFormattingData textFormatting = 5;
+      }
+    }
+
+    message ParameterMapper {
+      Mapper parameterData = 1;
+
+      oneof RelativePosition {
+        InlineAlignmentData inlineAlignment = 2;
+        TextFormattingData.AbsoluteAlignment absoluteAlignment = 3;
+        BakedAlignmentData bakedAlignment = 4;
+      }
+    }
+
+    message BakedElementMapper {
+      Mapper parameterData = 1;
+
+      oneof Value {
+        StructuredTextSpecifier value = 2;
+        ImageSpecifier image = 3;
+      }
+
+      oneof RelativePosition {
+        InlineAlignmentData inlineAlignment = 4;
+        TextFormattingData.AbsoluteAlignment absoluteAlignment = 5;
+      }
+    }
+
+    message PageFormattingData {
+      string themeColor = 1;
+    }
+
+    string key = 1;
+    repeated ParameterMapper parameterConsumer = 2;
+    repeated BakedElementMapper bakedElements = 3;
+    optional PageFormattingData pageFormatting = 4;
+  }
+
+  message MasterConsumer {
+    message ParamValue {
+      string param = 1;
+
+      oneof Value {
+        StructuredTextSpecifier value = 2;
+        ImageSpecifier image = 3;
+      }
+    }
+
+    string master = 1;
+    repeated ParamValue params = 2;
+  }
+
+
+  message Section {
+    message Page {
+      message StructuredTextContainer {
+        repeated StructuredTextSpecifier contents = 1;
+      }
+
+      oneof TextSpecificationType {
+        StructuredTextContainer text = 1;
+        MasterConsumer usingMaster = 2;
+      }
+
+      string title = 3;
+      int32 index = 4;
+      optional string subtitle = 5;
+      optional string author = 6;
+      optional string themeColor = 7;
+    }
+
+    string name = 1;
+    int32 index = 2;
+    optional string themeColor = 3;
+    repeated Page pages = 4;
+
+    bool hasCover = 5;
+    optional ImageSpecifier coverImage = 6;
+  }
+
+
+  repeated Global globals = 1;
+
+  repeated Master masters = 2;
+  repeated Section sections = 3;
 }

--- a/lib/data_classes/protobuf/magazines.proto.md
+++ b/lib/data_classes/protobuf/magazines.proto.md
@@ -1,0 +1,33 @@
+# Magazine data structure
+
+**How to construct a magazine, and a (brief) implementation guide for rendering.**
+
+## Building a magazine
+
+This section of the guide will discuss how to approach converting a magazine issue document from text into the `magazine.proto` format. It is assumed that you already have specified the magazine itself, as well as issue metadata -- this `proto` is only intended for specifying the actual issue contents (e.g. imagine it as an alternative to a `.pdf` file).
+
+### Key concepts
+
+If you are unfamiliar with the world magazine editing, there are a few key concepts which one needs to understand how this format is designed/operated semantically. In order to be as simple to use as possible, it is structured similarly to how a magazine layout may be structured in publishing software; therefore, much of the terminology is derived from there.
+
+ - **Master** - a 'master' is a template for a page, which can be re-used and centrally edited to update in multiple places. Imagine it like a Flutter or React component, in that it renders elements based on the props it is given, and can be called multiple times. Just as a component can take children, a master can take `params`, which specify strings/images to insert in key places within the template.
+ - **Global** - put simply, a 'global' is a little like a variable. They are defined in one place in the file/JSON tree, and can be imported in any reference. In this format, they currently behave similarly to `@mixin`s in `s[ac]ss`, in that they hold styling information which can be applied to anything which references it (but, if overridden by a formatting specifier lower in the tree, that is used instead - like `<style>` overriding classes), and that they can also make use of arguments passed to them.
+ - **Section** - a section is a chapter of an issue, e.g. 'Reader submissions'. Although not every magazine may have sections, they are necessary to use for simplicity of formatting (since it is far simpler to _get around_ using them if you don't want to, than it is to manually implement them if they weren't built into the specification). An easy way to get around sections (if they are not needed for a given issue) is to specify a single section, without any color/other metadata, and setting the `title` of the section to match the title of the issue.
+ - **Pages** - although this is fairly straightforward, it is important to keep in mind that in such a mobile environment, a 'page' refers to an entire article - individual articles are not to be paginated into `100vh` screens, but rendered as-is. The necessity for 'pages', as opposed to 'articles', is that some pages might _not_ be articles, but rather large images, infographics, crosswords/puzzles, etc..
+
+### Implementing properties
+
+#### Globals
+
+Globals are specified at the top level of the `proto` tree, within the `repeated` property `globals`. Each of these corresponds to a global definition object, which looks like this:
+
+```json
+{
+  "key": "global_name",
+  
+  // Refers to enum value - Text=0, Image=1.
+  "acceptedType": 0,
+  
+  
+}
+```


### PR DESCRIPTION
The purpose of this branch is to solve #14 - i.e., create a definition format by which magazines can define their issue contents (similarly to/as an alternative to a .pdf file), as well as allowing for future issues to create a simple, straightforward implementation of such format.

## To-do:

- Format
  - [x] Add page master support
  - [x] Add global mixin support
  - [x] Add page/section definitions
  - [x] Add simple, mobile-friendly styling options for images and text
  - [ ] Add front-cover definitions
- Documentation
  - [x] Create documentation README, describe basic intentions
  - [x] Document key terms/sections
  - [ ] Add implementation guide for magazine authors
  - [ ] Add implementation guide for app developers